### PR TITLE
Changed parameter three of SDL_Vulkan_GetInstanceExtensions from (_pt…

### DIFF
--- a/main.rkt
+++ b/main.rkt
@@ -2305,7 +2305,7 @@
 (define-sdl2 SDL_Vulkan_UnloadLibrary (_fun -> _void)
     #:make-fail make-not-available)
 
-(define-sdl2 SDL_Vulkan_GetInstanceExtensions (_fun _SDL_Window* _uint* (_ptr o _string) -> _SDL_bool)
+(define-sdl2 SDL_Vulkan_GetInstanceExtensions (_fun _SDL_Window* _uint* _pointer) -> _SDL_bool)
     #:make-fail make-not-available)
 
 (define-sdl2 SDL_Vulkan_CreateSurface (_fun _SDL_Window* _VkInstance _VkSurfaceKHR* -> _SDL_bool)


### PR DESCRIPTION
…r o _string) to _pointer, fixing arity issue (#3)

I also tried it with (_ptr io _string) but the same arity issue came up. I figure define_sdl isn't reading (_ptr ...) expressions as arguments