### PR TITLE
convert relative path to complete path

### DIFF
--- a/examples/events.rkt
+++ b/examples/events.rkt
@@ -23,7 +23,7 @@
                                      640 480 '()))
     (define renderer (SDL_CreateRenderer window -1 '()))
 
-    (define image (SDL_LoadBMP "spaceship.bmp"))
+    (define image (SDL_LoadBMP (path->complete-path "spaceship.bmp")))
     (define texture (SDL_CreateTextureFromSurface renderer image))
     (SDL_FreeSurface image)
 

--- a/examples/simple.rkt
+++ b/examples/simple.rkt
@@ -19,7 +19,7 @@
         (eprintf "SDL_CreateRenderer Error: ~a\n" (SDL_GetError))
         (exit 1))
     (define bmp
-        (SDL_LoadBMP "grumpy-cat.bmp"))
+        (SDL_LoadBMP (path->complete-path "grumpy-cat.bmp")))
     (unless bmp
         (eprintf "SDL_LoadBMP Error: ~a\n" (SDL_GetError)))
     (define tex


### PR DESCRIPTION
The examples did not when racket was initially started from another directory because image files were failing to load. It was especially problematic when using drracket because it starts racket backend in home directory before running the program.

From ffi docs https://docs.racket-lang.org/foreign/String_Types.html#%28def._%28%28quote._~23~25foreign%29.__path%29%29

> Beware that changing the current directory via [current-directory](https://docs.racket-lang.org/reference/Filesystem.html#%28def._%28%28quote._~23~25kernel%29._current-directory%29%29) does n<ot change the OS-level current directory as seen by foreign library functions. Paths normally should be converted to absolute form using [path->complete-path](https://docs.racket-lang.org/reference/Manipulating_Paths.html#%28def._%28%28quote._~23~25kernel%29._path-~3ecomplete-path%29%29) (which uses the [current-directory](https://docs.racket-lang.org/reference/Filesystem.html#%28def._%28%28quote._~23~25kernel%29._current-directory%29%29) parameter) before passing them to a foreign function.